### PR TITLE
feat: comparator default to `Array.prototype.sort()` behavior

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ export type Comparator<T> = (a: T, b: T) => number
  * @param insertValue value to be added to the array
  * @param comparator function that helps determine where to insert the value (
  */
-export function binaryInsert<T>(array: T[], insertValue: T, comparator: Comparator<T>) {
+export function binaryInsert<T>(array: T[], insertValue: T, comparator: Comparator<T> = (a, b) => a < b ? -1 : 1) {
   /*
   * These two conditional statements are not required, but will avoid the
   * while loop below, potentially speeding up the insert by a decent amount.


### PR DESCRIPTION
Ability to pass your own still there, just falls back if you don't provide one.